### PR TITLE
Bounds for Compat.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 AbstractTrees = "0.2, 0.3"
-Compat = "2, 3.2"
+Compat = "2, 3"
 Glob = "1"
 Gumbo = "0.5, 0.7"
 HTTP = "0.8"


### PR DESCRIPTION
According to the registry, https://github.com/JuliaRegistries/General/blob/master/P/PhysOcean/Compat.toml this package bounds Compat.jl to version 2.

I think this PR allows version 3 as was probably intended?